### PR TITLE
removal of phantomjs dependency and testing the ajv pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "eslint": "if-node-version '>=4' eslint lib/*.js lib/compile/*.js spec",
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-fast": "AJV_FAST_TEST=true npm run test-spec",
+    "test-pack": "AJV_PACK=true npm run test-spec",
+    "test-pack-fast": "AJV_PACK=true AJV_FAST_TEST=true npm run test-spec",
     "test-debug": "mocha spec/*.spec.js --debug-brk -R spec",
     "test-cov": "istanbul cover -x '**/spec/**' node_modules/mocha/bin/_mocha -- spec/*.spec.js -R spec",
     "test-ts": "tsc --target ES5 --noImplicitAny lib/ajv.d.ts",
@@ -56,6 +58,7 @@
     "json-stable-stringify": "^1.0.1"
   },
   "devDependencies": {
+    "ajv-pack": "^0.1.0",
     "bluebird": "^3.1.5",
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",

--- a/spec/ajv_instances.js
+++ b/spec/ajv_instances.js
@@ -4,9 +4,20 @@ var Ajv = require('./ajv');
 
 module.exports = getAjvInstances;
 
+var isBrowser = typeof window == 'object';
+var packTest = !isBrowser && process.env.AJV_PACK == 'true';
+
 
 function getAjvInstances(options, extraOpts) {
-  return _getAjvInstances(options, extraOpts || {});
+  var instances = _getAjvInstances(options, extraOpts || {});
+  if (!packTest) return instances;
+  var ajvPack = require('' + 'ajv-pack');
+  extraOpts = extraOpts || {};
+  extraOpts.sourceCode = true;
+  var packInstances = _getAjvInstances(options, extraOpts).map(function (ajv) {
+    return ajvPack.instance(ajv);
+  });
+  return instances.concat(packInstances);
 }
 
 function _getAjvInstances(opts, useOpts) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Removal of phantomjs dependency from the package.
**Logs before removal of phantomjs dependency:**
npm WARN deprecated @types/commander@2.12.2: This is a stub types definition for commander (https://github.com/tj/commander.js). commander provides its own type definitions, so you don't need @types/commander installed!

> nodent-runtime@3.2.1 install /root/src/github.com/pruthvireddy1991/ajv/node_modules/nodent-runtime
> node build.js

## Built /root/src/github.com/pruthvireddy1991/ajv/node_modules/nodent-runtime/dist/index.js

> phantomjs-prebuilt@2.1.16 install /root/src/github.com/pruthvireddy1991/ajv/node_modules/phantomjs-prebuilt
> node install.js

PhantomJS not found on PATH
Unexpected platform or architecture: linux/arm64
It seems there is no binary available for your platform/architecture
Try to install PhantomJS globally

> wd@1.10.3 install /root/src/github.com/pruthvireddy1991/ajv/node_modules/wd
> node scripts/build-browser-scripts


> pre-commit@1.2.2 install /root/src/github.com/pruthvireddy1991/ajv/node_modules/pre-commit
> node install.js


> spawn-sync@1.0.15 postinstall /root/src/github.com/pruthvireddy1991/ajv/node_modules/spawn-sync
> node postinstall


> sauce-connect-launcher@1.2.4 postinstall /root/src/github.com/pruthvireddy1991/ajv/node_modules/sauce-connect-launcher
> node scripts/install.js || nodejs scripts/install.js

npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
npm WARN lifecycle ajv@6.5.2~prepublish: cannot run in wd ajv@6.5.2 npm run build && npm run bundle (wd=/root/src/github.com/pruthvireddy1991/ajv)
npm WARN ajv-async@1.0.1 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"arm64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: phantomjs-prebuilt@2.1.16 (node_modules/phantomjs-prebuilt):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: phantomjs-prebuilt@2.1.16 install: `node install.js`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

added 1036 packages from 1342 contributors and audited 6061 packages in 74.997s
found 0 vulnerabilities

**Logs after removal:**
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
npm WARN lifecycle ajv@6.5.2~prepublish: cannot run in wd ajv@6.5.2 npm run build && npm run bundle (wd=/root/pruthvi/node/ajv)
npm WARN ajv-async@1.0.1 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"arm64"})

audited 5848 packages in 22.953s
found 0 vulnerabilities

**Unchanged test result:**
Final Result:
 2379 passing (4m)
  30 pending


=============================== Coverage summary ===============================
Statements   : 99.22% ( 3200/3225 )
Branches     : 93.48% ( 1849/1978 )
Functions    : 100% ( 152/152 )
Lines        : 99.68% ( 3107/3117 )
================================================================================ 

**What changes did you make?**
Updated package.json by replacing karma-phantomjs-launcher with karma-chrome-launcher

**Is there anything that requires more attention while reviewing?**
To remove phantomjs even as optional dependency, update jshint package package.json by removing phantomjs from the dependencies list.